### PR TITLE
Refactor joint control to support all limbs

### DIFF
--- a/User/APP/body_task.c
+++ b/User/APP/body_task.c
@@ -2,7 +2,7 @@
   *********************************************************************
   * @file      body_task.c/h
   * @brief     该任务控制腰部的一个电机，是DM6006，这个电机挂载在can3总线上
-  * @note       
+  * @note
   * @history
   *
   @verbatim
@@ -12,99 +12,205 @@
   @endverbatim
   *********************************************************************
   */
-	
+
 #include "body_task.h"
 #include "fdcan.h"
 #include "cmsis_os.h"
 #include "chassisR_task.h"
+#include <stdbool.h>
+#include <stddef.h>
 
 extern INS_t INS;
-extern chassis_t chassis_move;															
+extern chassis_t chassis_move;
 body_t robot_body;
 
-uint32_t BODY_TIME=1;	
-
-float my_kd3=1.1f;
-float my_kp3=90.0f;
-float my_pos3=0.0f;
-float my_pos3_set=0.0f;
+uint32_t BODY_TIME=1;
 int c=0;
 uint8_t record_flag=0;
-FDCAN_ProtocolStatusTypeDef fdcan_protocol_status;
-FDCAN_ErrorCountersTypeDef err_cnt;
-//void mit_ctrl3(hcan_t* hcan, uint16_t motor_id, float pos, float vel,float kp, float kd, float torq)
+
+typedef struct
+{
+    RobotJointId joint;
+    float target_pos;
+    float target_vel;
+    float target_kp;
+    float target_kd;
+    float target_torque;
+    float ramp;
+    float current_pos;
+} BodyJointCommand;
+
+static BodyJointCommand body_joint_commands[] = {
+    {ROBOT_JOINT_WAIST_YAW, 0.0f, 0.0f, 90.0f, 1.1f, 0.0f, 0.001f, 0.0f},
+    {ROBOT_JOINT_NECK_YAW, 0.0f, 0.0f, 60.0f, 0.8f, 0.0f, 0.002f, 0.0f},
+    {ROBOT_JOINT_NECK_PITCH, 0.0f, 0.0f, 60.0f, 0.8f, 0.0f, 0.002f, 0.0f},
+    {ROBOT_JOINT_NECK_ROLL, 0.0f, 0.0f, 60.0f, 0.8f, 0.0f, 0.002f, 0.0f},
+    {ROBOT_JOINT_LEFT_ARM_SHOULDER_PITCH, 0.0f, 0.0f, 40.0f, 0.6f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_LEFT_ARM_SHOULDER_ROLL, 0.0f, 0.0f, 35.0f, 0.6f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_LEFT_ARM_ELBOW, 0.0f, 0.0f, 35.0f, 0.5f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_LEFT_ARM_WRIST, 0.0f, 0.0f, 30.0f, 0.5f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_RIGHT_ARM_SHOULDER_PITCH, 0.0f, 0.0f, 40.0f, 0.6f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_RIGHT_ARM_SHOULDER_ROLL, 0.0f, 0.0f, 35.0f, 0.6f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_RIGHT_ARM_ELBOW, 0.0f, 0.0f, 35.0f, 0.5f, 0.0f, 0.003f, 0.0f},
+    {ROBOT_JOINT_RIGHT_ARM_WRIST, 0.0f, 0.0f, 30.0f, 0.5f, 0.0f, 0.003f, 0.0f},
+};
+
+static BodyJointCommand *Body_FindCommand(RobotJointId joint)
+{
+    for(size_t i = 0; i < sizeof(body_joint_commands)/sizeof(body_joint_commands[0]); ++i)
+    {
+        if(body_joint_commands[i].joint == joint)
+        {
+            return &body_joint_commands[i];
+        }
+    }
+    return NULL;
+}
+
+static void Body_UpdateCommand(BodyJointCommand *command, bool active)
+{
+    if(command == NULL)
+    {
+        return;
+    }
+
+    if(!active)
+    {
+        command->current_pos = 0.0f;
+        RobotJointManager_SendMIT(command->joint, 0.0f, 0.0f, 0.0f, command->target_kd, 0.0f);
+        return;
+    }
+
+    slope_following(&command->target_pos, &command->current_pos, command->ramp);
+    RobotJointManager_SendMIT(command->joint, command->current_pos, command->target_vel, command->target_kp, command->target_kd, command->target_torque);
+}
+
+static void Body_ProcessUpperBody(bool active)
+{
+    for(size_t i = 0; i < sizeof(body_joint_commands)/sizeof(body_joint_commands[0]); ++i)
+    {
+        if(body_joint_commands[i].joint == ROBOT_JOINT_WAIST_YAW)
+        {
+            continue;
+        }
+        Body_UpdateCommand(&body_joint_commands[i], active);
+    }
+}
+
+void Body_SetJointTarget(RobotJointId joint, float position, float velocity, float kp, float kd, float torque)
+{
+    BodyJointCommand *cmd = Body_FindCommand(joint);
+    if(cmd == NULL)
+    {
+        return;
+    }
+    cmd->target_pos = position;
+    cmd->target_vel = velocity;
+    cmd->target_kp = kp;
+    cmd->target_kd = kd;
+    cmd->target_torque = torque;
+}
+
+void Body_SetJointRamp(RobotJointId joint, float ramp)
+{
+    BodyJointCommand *cmd = Body_FindCommand(joint);
+    if(cmd == NULL)
+    {
+        return;
+    }
+    cmd->ramp = ramp;
+}
+
 void slope_following(float *target,float *set,float acc)
 {
-	if(*target > *set)
-	{
-		*set = *set + acc;
-		if(*set >= *target)
-		{
-			*set = *target;
-		}		
-	}
-	else if(*target < *set)
-	{
-		*set = *set - acc;
-		if(*set <= *target)
-		{
-			*set = *target;
-		}	
-	}
+        if(*target > *set)
+        {
+                *set = *set + acc;
+                if(*set >= *target)
+                {
+                        *set = *target;
+                }
+        }
+        else if(*target < *set)
+        {
+                *set = *set - acc;
+                if(*set <= *target)
+                {
+                        *set = *target;
+                }
+        }
 }
 
 void Body_task(void)
 {
-	osDelay(3000);
+        osDelay(3000);
   body_init(&robot_body);
 
-	while(1)
-	{	
-		if(chassis_move.joint_motor[0].para.kp_int_test!=0&&chassis_move.start_flag==1&&record_flag==0)	
-		{
-			record_flag=1;
-			my_pos3_set=robot_body.loin_motor.para.pos;
-		}
-		//chassis_move.joint_motor[0].para.kp_int_test!=0&&
-		if(chassis_move.joint_motor[0].para.kp_int_test!=0&&chassis_move.start_flag==1)	
-		{
-			slope_following(&my_pos3,&my_pos3_set,0.001f);
-			//腰电机
-			mit_ctrl3(&hfdcan3,0x09, my_pos3_set, 0.0f,my_kp3, my_kd3,0.0f);//6006 腰电机
-		}
-		else
-		{ 
-			record_flag=0;
-			//腰电机
-			mit_ctrl3(&hfdcan3,0x09, 0.0f, 0.0f,0.0f, my_kd3,0.0f);//6006 腰电机
-			//HAL_FDCAN_GetProtocolStatus(&hfdcan3, &fdcan_protocol_status);
-			//HAL_FDCAN_GetErrorCounters(&hfdcan3, &err_cnt);		
-		}
-		if(c==1)
-		{
-		  save_motor_zero(&hfdcan3,0x09, MIT_MODE);
-		  osDelay(BODY_TIME);			
-		}
-		osDelay(BODY_TIME);
-	}
+        BodyJointCommand *waist_cmd = Body_FindCommand(ROBOT_JOINT_WAIST_YAW);
+        Joint_Motor_t *waist_motor = RobotJointManager_GetMotor(ROBOT_JOINT_WAIST_YAW);
+        Joint_Motor_t *left_pitch_motor = RobotJointManager_GetMotor(ROBOT_JOINT_LEFT_LEG_HIP_PITCH);
+
+        while(1)
+        {
+                bool leg_ready = false;
+                if(left_pitch_motor != NULL && chassis_move.start_flag==1)
+                {
+                        leg_ready = (left_pitch_motor->para.kp_int_test != 0);
+                }
+
+                if(waist_cmd != NULL && waist_motor != NULL)
+                {
+                        if(leg_ready)
+                        {
+                                if(record_flag==0)
+                                {
+                                        record_flag=1;
+                                        waist_cmd->current_pos = waist_motor->para.pos;
+                                }
+                                slope_following(&waist_cmd->target_pos, &waist_cmd->current_pos, waist_cmd->ramp);
+                                RobotJointManager_SendMIT(waist_cmd->joint, waist_cmd->current_pos, waist_cmd->target_vel, waist_cmd->target_kp, waist_cmd->target_kd, waist_cmd->target_torque);
+                        }
+                        else
+                        {
+                                record_flag=0;
+                                waist_cmd->current_pos = 0.0f;
+                                RobotJointManager_SendMIT(waist_cmd->joint, 0.0f, 0.0f, 0.0f, waist_cmd->target_kd, 0.0f);
+                        }
+                }
+
+                bool upper_active = (robot_body.start_flag != 0U) && (chassis_move.start_flag==1);
+                Body_ProcessUpperBody(upper_active);
+
+                if(c==1)
+                {
+                  RobotJointManager_SaveZero(ROBOT_JOINT_WAIST_YAW);
+                  osDelay(BODY_TIME);
+                }
+                osDelay(BODY_TIME);
+        }
 }
 
 void body_init(body_t *body)
 {
-	joint_motor_init(&body->loin_motor,0x09,MIT_MODE);//腰电机
-	
-	//腰电机
-	for(int j=0;j<10;j++)
-	{
-    enable_motor_mode(&hfdcan3,body->loin_motor.para.id,body->loin_motor.mode);
-	  osDelay(20);
-	}
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_WAIST_YAW, &body->loin_motor, MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_NECK_YAW, &body->neck_motor[0], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_NECK_PITCH, &body->neck_motor[1], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_NECK_ROLL, &body->neck_motor[2], MIT_MODE);
+
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_ARM_SHOULDER_PITCH, &body->left_arm_motor[0], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_ARM_SHOULDER_ROLL, &body->left_arm_motor[1], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_ARM_ELBOW, &body->left_arm_motor[2], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_ARM_WRIST, &body->left_arm_motor[3], MIT_MODE);
+
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_RIGHT_ARM_SHOULDER_PITCH, &body->right_arm_motor[0], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_RIGHT_ARM_SHOULDER_ROLL, &body->right_arm_motor[1], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_RIGHT_ARM_ELBOW, &body->right_arm_motor[2], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_RIGHT_ARM_WRIST, &body->right_arm_motor[3], MIT_MODE);
+
+        RobotJointManager_EnableLimb(ROBOT_LIMB_WAIST, 10, 20);
+        RobotJointManager_EnableLimb(ROBOT_LIMB_NECK, 10, 20);
+        RobotJointManager_EnableLimb(ROBOT_LIMB_LEFT_ARM, 10, 20);
+        RobotJointManager_EnableLimb(ROBOT_LIMB_RIGHT_ARM, 10, 20);
+
+        body->start_flag = 1;
 }
-
-
-
-
-
-
-
-

--- a/User/APP/body_task.h
+++ b/User/APP/body_task.h
@@ -7,25 +7,18 @@
 #include "chassisL_task.h"
 #include "INS_task.h"
 
-
-
 typedef struct
 {
-  Joint_Motor_t arm_motor[8];
-  Joint_Motor_t loin_motor;
-	uint8_t start_flag;//启动标志
-	
+    Joint_Motor_t neck_motor[3];
+    Joint_Motor_t left_arm_motor[4];
+    Joint_Motor_t right_arm_motor[4];
+    Joint_Motor_t loin_motor;
+    uint8_t start_flag;//志
 } body_t;
-
 
 extern void body_init(body_t *body);
 extern void Body_task(void);
-
-
-
+extern void Body_SetJointTarget(RobotJointId joint, float position, float velocity, float kp, float kd, float torque);
+extern void Body_SetJointRamp(RobotJointId joint, float ramp);
 
 #endif
-
-
-
-

--- a/User/APP/chassisL_task.c
+++ b/User/APP/chassisL_task.c
@@ -17,6 +17,7 @@
 #include "fdcan.h"
 
 #include "cmsis_os.h"
+#include <stddef.h>
 
 extern chassis_t chassis_move;
 
@@ -27,107 +28,66 @@ float my_vel=0.0f;
 float my_kp=0.0f;
 float my_pos=0.0f;
 int b=0;
+
+static const RobotJointId left_leg_joint_order[] = {
+    ROBOT_JOINT_LEFT_LEG_HIP_PITCH,
+    ROBOT_JOINT_LEFT_LEG_HIP_YAW,
+    ROBOT_JOINT_LEFT_LEG_HIP_ROLL,
+    ROBOT_JOINT_LEFT_LEG_KNEE,
+    ROBOT_JOINT_LEFT_LEG_ANKLE_PITCH,
+    ROBOT_JOINT_LEFT_LEG_ANKLE_ROLL,
+    ROBOT_JOINT_LEFT_LEG_TOE,
+};
+
+#define LEFT_LEG_JOINT_COUNT (sizeof(left_leg_joint_order) / sizeof(left_leg_joint_order[0]))
 void ChassisL_task(void)
 {
 	chassis_move.start_flag=1;
 	osDelay(2000);
     ChassisL_init(&chassis_move);
-	
-	dm6248p_fbdata_init(&chassis_move.joint_motor[0]);
-    dm6248p_fbdata_init(&chassis_move.joint_motor[1]);
-	dm6248p_fbdata_init(&chassis_move.joint_motor[2]);
-	dm4340_fbdata_init(&chassis_move.joint_motor[3]);
-	dm4340_fbdata_init(&chassis_move.joint_motor[4]);
-	dm4340_fbdata_init(&chassis_move.joint_motor[5]);
-	dm4340_fbdata_init(&chassis_move.joint_motor[6]);
-	
-	while(1)
-	{	
-		 if(chassis_move.start_flag==1)	
-		 {	
-			mit_ctrl_test(&hfdcan2,0x01,&chassis_move.joint_motor[0]);
-			mit_ctrl_test(&hfdcan2,0x02,&chassis_move.joint_motor[1]);
-			mit_ctrl_test(&hfdcan2,0x03,&chassis_move.joint_motor[2]);
-			mit_ctrl_test(&hfdcan2,0x04,&chassis_move.joint_motor[3]);
-			mit_ctrl_test(&hfdcan2,0x05,&chassis_move.joint_motor[4]);
-			mit_ctrl_test(&hfdcan2,0x06,&chassis_move.joint_motor[5]);
-			mit_ctrl_test(&hfdcan2,0x07,&chassis_move.joint_motor[6]);
-				
-		 }
-		 else
-		 {
-			mit_ctrl2(&hfdcan2,0x01, my_pos,my_vel,my_kp, my_kd,0.0f);//left_pitch
-			mit_ctrl2(&hfdcan2,0x02, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_yaw
-			mit_ctrl2(&hfdcan2,0x03, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_roll
-			mit_ctrl2(&hfdcan2,0x04, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_calf
-			mit_ctrl2(&hfdcan2,0x05, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_foot 
-			mit_ctrl2(&hfdcan2,0x06, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_foot 
-			mit_ctrl2(&hfdcan2,0x07, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_foot 
-		 }
-		 
-		if(b==1)
-		{
-		 	// save_motor_zero(&hfdcan2,0x05, MIT_MODE);
-			// osDelay(CHASSL_TIME);
-			save_motor_zero(&hfdcan2,0x04, MIT_MODE);
-			// osDelay(CHASSL_TIME);
-			// save_motor_zero(&hfdcan2,0x03, MIT_MODE);
-			// osDelay(CHASSL_TIME);
-			// save_motor_zero(&hfdcan2,0x02, MIT_MODE);
-			// osDelay(CHASSL_TIME);
-			// save_motor_zero(&hfdcan2,0x01, MIT_MODE);
-			osDelay(CHASSL_TIME);			
-		}
-		 osDelay(CHASSL_TIME); 
 
-	}
+        while(1)
+        {
+                 if(chassis_move.start_flag==1)
+                 {
+                        for(size_t i = 0; i < LEFT_LEG_JOINT_COUNT; ++i)
+                        {
+                                RobotJointManager_SendMITUsingCache(left_leg_joint_order[i]);
+                        }
+
+                 }
+                 else
+                 {
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_HIP_PITCH, my_pos,my_vel,my_kp, my_kd,0.0f);//left_pitch
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_HIP_YAW, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_yaw
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_HIP_ROLL, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_roll
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_KNEE, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_calf
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_ANKLE_PITCH, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_foot
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_ANKLE_ROLL, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_foot
+                        RobotJointManager_SendMIT(ROBOT_JOINT_LEFT_LEG_TOE, 0.0f, 0.0f,0.0f, 0.0f,0.0f);//left_foot
+                 }
+
+                if(b==1)
+                {
+                        RobotJointManager_SaveZero(ROBOT_JOINT_LEFT_LEG_KNEE);
+                        osDelay(CHASSL_TIME);
+                }
+                 osDelay(CHASSL_TIME);
+
+        }
 }
 
 void ChassisL_init(chassis_t *chassis)
 {
-	joint_motor_init(&chassis->joint_motor[0],1,MIT_MODE);
-	joint_motor_init(&chassis->joint_motor[1],2,MIT_MODE);
-	joint_motor_init(&chassis->joint_motor[2],3,MIT_MODE);
-	joint_motor_init(&chassis->joint_motor[3],4,MIT_MODE);
-	joint_motor_init(&chassis->joint_motor[4],5,MIT_MODE);
-	joint_motor_init(&chassis->joint_motor[5],6,MIT_MODE);
-	joint_motor_init(&chassis->joint_motor[6],7,MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_HIP_PITCH, &chassis->joint_motor[0], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_HIP_YAW, &chassis->joint_motor[1], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_HIP_ROLL, &chassis->joint_motor[2], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_KNEE, &chassis->joint_motor[3], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_ANKLE_PITCH, &chassis->joint_motor[4], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_ANKLE_ROLL, &chassis->joint_motor[5], MIT_MODE);
+        RobotJointManager_RegisterJoint(ROBOT_JOINT_LEFT_LEG_TOE, &chassis->joint_motor[6], MIT_MODE);
 
-	for(int j=0;j<10;j++)
-	{
-	  enable_motor_mode(&hfdcan2,chassis->joint_motor[0].para.id,chassis->joint_motor[0].mode);
-	  osDelay(20);
-	}
-	for(int j=0;j<10;j++)
-	{
-	  enable_motor_mode(&hfdcan2,chassis->joint_motor[1].para.id,chassis->joint_motor[1].mode);
-	  osDelay(20);
-	}
-	for(int j=0;j<10;j++)
-	{
-      enable_motor_mode(&hfdcan2,chassis->joint_motor[2].para.id,chassis->joint_motor[2].mode);
-	  osDelay(20);
-	}
-	for(int j=0;j<10;j++)
-	{
-      enable_motor_mode(&hfdcan2,chassis->joint_motor[3].para.id,chassis->joint_motor[3].mode);
-	  osDelay(20);
-	}
-	for(int j=0;j<10;j++)
-	{
-      enable_motor_mode(&hfdcan2,chassis->joint_motor[4].para.id,chassis->joint_motor[4].mode);
-	  osDelay(20);
-	}
-	for(int j=0;j<10;j++)
-	{
-      enable_motor_mode(&hfdcan2,chassis->joint_motor[5].para.id,chassis->joint_motor[5].mode);
-	  osDelay(20);
-	}
-	for(int j=0;j<10;j++)
-	{
-      enable_motor_mode(&hfdcan2,chassis->joint_motor[6].para.id,chassis->joint_motor[6].mode);
-	  osDelay(20);
-	}
+        RobotJointManager_EnableLimb(ROBOT_LIMB_LEFT_LEG, 10, 20);
 }
 
 

--- a/User/Bsp/can_bsp.c
+++ b/User/Bsp/can_bsp.c
@@ -155,69 +155,36 @@ uint8_t canx_send_data(FDCAN_HandleTypeDef *hcan, uint16_t id, uint8_t *data, ui
 
 extern chassis_t chassis_move;
 extern body_t robot_body;
-int64_t mybuff[7]={0};
-int64_t mybuff3[9]={0};
 void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs)
-{ 
+{
   if((RxFifo0ITs & FDCAN_IT_RX_FIFO0_NEW_MESSAGE) != RESET)
   {
     if(hfdcan->Instance == FDCAN1)
     {
-      /* Retrieve Rx messages from RX FIFO0 */
-			memset(g_Can1RxData, 0, sizeof(g_Can1RxData));	//����ǰ���������	
+      memset(g_Can1RxData, 0, sizeof(g_Can1RxData));
       HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO0, &RxHeader1, g_Can1RxData);
-			
-			switch(RxHeader1.Identifier)
-			{//����
-				case 0x19 :dm4340_fbdata(&chassis_move.joint_motor[13], g_Can1RxData,RxHeader1.DataLength);mybuff[0]++;break;
-				case 0x18 :dm4340_fbdata(&chassis_move.joint_motor[12], g_Can1RxData,RxHeader1.DataLength);mybuff[1]++;break;
-        		case 0x17 :dm4340_fbdata(&chassis_move.joint_motor[11], g_Can1RxData,RxHeader1.DataLength);mybuff[2]++;break;
-        		case 0x15 :dm4340_fbdata(&chassis_move.joint_motor[10], g_Can1RxData,RxHeader1.DataLength);mybuff[3]++;break;	         	
-				case 0x1A :dm4340_fbdata(&chassis_move.joint_motor[9], g_Can1RxData,RxHeader1.DataLength);mybuff[4]++;break;
-        		case 0x12 :dm4340_fbdata(&chassis_move.joint_motor[8], g_Can1RxData,RxHeader1.DataLength);mybuff[5]++;break;
-				case 0x11 :dm4340_fbdata(&chassis_move.joint_motor[7], g_Can1RxData,RxHeader1.DataLength);mybuff[6]++;break;
-				
-				default: break;
-			}			
-	  }
-		if(hfdcan->Instance == FDCAN3)
+      RobotJointManager_HandleFeedback(hfdcan, RxHeader1.Identifier, g_Can1RxData, RxHeader1.DataLength);
+    }
+    if(hfdcan->Instance == FDCAN3)
     {
-      /* Retrieve Rx messages from RX FIFO0 */
-			memset(g_Can3RxData, 0, sizeof(g_Can3RxData));	//����ǰ���������	
+      memset(g_Can3RxData, 0, sizeof(g_Can3RxData));
       HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO0, &RxHeader3, g_Can3RxData);
-			
-			switch(RxHeader3.Identifier)
-			{ 		
-				case 0x19 :dm6006_fbdata(&robot_body.loin_motor, g_Can3RxData,RxHeader3.DataLength);mybuff3[8]++;break;	
-				
-				default: break;
-			}			
-	  }
+      RobotJointManager_HandleFeedback(hfdcan, RxHeader3.Identifier, g_Can3RxData, RxHeader3.DataLength);
+    }
   }
 }
-int64_t mybuff2[5]={0};
 void HAL_FDCAN_RxFifo1Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo1ITs)
 {
   if((RxFifo1ITs & FDCAN_IT_RX_FIFO1_NEW_MESSAGE) != RESET)
   {
     if(hfdcan->Instance == FDCAN2)
     {
-      /* Retrieve Rx messages from RX FIFO0 */
-			memset(g_Can2RxData, 0, sizeof(g_Can2RxData));
+      memset(g_Can2RxData, 0, sizeof(g_Can2RxData));
       HAL_FDCAN_GetRxMessage(hfdcan, FDCAN_RX_FIFO1, &RxHeader2, g_Can2RxData);
-			switch(RxHeader2.Identifier)
-			{//����
-        case 0x15 :dm4340_fbdata(&chassis_move.joint_motor[0], g_Can2RxData,RxHeader2.DataLength);mybuff2[0]++;break;
-        case 0x14 :dm4340_fbdata(&chassis_move.joint_motor[1], g_Can2RxData,RxHeader2.DataLength);mybuff2[1]++;break;	         	
-				case 0x13 :dm4340_fbdata(&chassis_move.joint_motor[2], g_Can2RxData,RxHeader2.DataLength);mybuff2[2]++;break;
-        case 0x12 :dm4340_fbdata(&chassis_move.joint_motor[3], g_Can2RxData,RxHeader2.DataLength);mybuff2[3]++;break;
-				case 0x11 :dm4340_fbdata(&chassis_move.joint_motor[4], g_Can2RxData,RxHeader2.DataLength);mybuff2[4]++;break;
-				default: break;
-			}	
+      RobotJointManager_HandleFeedback(hfdcan, RxHeader2.Identifier, g_Can2RxData, RxHeader2.DataLength);
     }
   }
 }
-
 void bsp_fdcan_set_baud(hcan_t *hfdcan, uint8_t mode, uint8_t baud)
 {
 	uint32_t nom_brp=0, nom_seg1=0, nom_seg2=0, nom_sjw=0;

--- a/User/Devices/DM_Motor/dm4310_drv.h
+++ b/User/Devices/DM_Motor/dm4310_drv.h
@@ -1,5 +1,7 @@
 #ifndef __DM4310_DRV_H__
 #define __DM4310_DRV_H__
+#include <stdbool.h>
+
 #include "main.h"
 #include "fdcan.h"
 #include "can_bsp.h"
@@ -132,11 +134,90 @@ typedef struct
 
 typedef struct
 {
-	uint16_t mode;
-	float wheel_T;//��챵�������Ť�أ���λΪN
-	
-	motor_fbpara_t para;	
+        uint16_t mode;
+        float wheel_T;//��챵�������Ť�أ���λΪN
+
+        motor_fbpara_t para;
 }Wheel_Motor_t ;
+
+typedef enum
+{
+    ROBOT_MOTOR_DM4310 = 0,
+    ROBOT_MOTOR_DM4340,
+    ROBOT_MOTOR_DM6006,
+    ROBOT_MOTOR_DM8006,
+    ROBOT_MOTOR_DM3507,
+    ROBOT_MOTOR_DM10010L,
+    ROBOT_MOTOR_DM6248P,
+    ROBOT_MOTOR_UNKNOWN
+} RobotMotorModel;
+
+typedef enum
+{
+    ROBOT_LIMB_WAIST = 0,
+    ROBOT_LIMB_NECK,
+    ROBOT_LIMB_LEFT_ARM,
+    ROBOT_LIMB_RIGHT_ARM,
+    ROBOT_LIMB_LEFT_LEG,
+    ROBOT_LIMB_RIGHT_LEG,
+    ROBOT_LIMB_COUNT
+} RobotLimb;
+
+typedef enum
+{
+    ROBOT_JOINT_WAIST_YAW = 0,
+    ROBOT_JOINT_NECK_YAW,
+    ROBOT_JOINT_NECK_PITCH,
+    ROBOT_JOINT_NECK_ROLL,
+    ROBOT_JOINT_LEFT_ARM_SHOULDER_PITCH,
+    ROBOT_JOINT_LEFT_ARM_SHOULDER_ROLL,
+    ROBOT_JOINT_LEFT_ARM_ELBOW,
+    ROBOT_JOINT_LEFT_ARM_WRIST,
+    ROBOT_JOINT_RIGHT_ARM_SHOULDER_PITCH,
+    ROBOT_JOINT_RIGHT_ARM_SHOULDER_ROLL,
+    ROBOT_JOINT_RIGHT_ARM_ELBOW,
+    ROBOT_JOINT_RIGHT_ARM_WRIST,
+    ROBOT_JOINT_LEFT_LEG_HIP_PITCH,
+    ROBOT_JOINT_LEFT_LEG_HIP_YAW,
+    ROBOT_JOINT_LEFT_LEG_HIP_ROLL,
+    ROBOT_JOINT_LEFT_LEG_KNEE,
+    ROBOT_JOINT_LEFT_LEG_ANKLE_PITCH,
+    ROBOT_JOINT_LEFT_LEG_ANKLE_ROLL,
+    ROBOT_JOINT_LEFT_LEG_TOE,
+    ROBOT_JOINT_RIGHT_LEG_HIP_PITCH,
+    ROBOT_JOINT_RIGHT_LEG_HIP_YAW,
+    ROBOT_JOINT_RIGHT_LEG_HIP_ROLL,
+    ROBOT_JOINT_RIGHT_LEG_KNEE,
+    ROBOT_JOINT_RIGHT_LEG_ANKLE_PITCH,
+    ROBOT_JOINT_RIGHT_LEG_ANKLE_ROLL,
+    ROBOT_JOINT_RIGHT_LEG_TOE,
+    ROBOT_JOINT_COUNT
+} RobotJointId;
+
+typedef struct
+{
+    RobotJointId joint_id;
+    RobotMotorModel model;
+    RobotLimb limb;
+    uint16_t command_id;
+    uint16_t feedback_id;
+    uint16_t default_mode;
+    hcan_t *bus;
+    const char *name;
+} RobotJointHardwareConfig;
+
+typedef struct
+{
+    RobotJointId joint_id;
+    Joint_Motor_t *joint;
+    RobotMotorModel model;
+    RobotLimb limb;
+    hcan_t *bus;
+    uint16_t command_id;
+    uint16_t feedback_id;
+    uint16_t mode;
+    const char *name;
+} RobotJointConfig;
 
 
 extern void dm6006_fbdata(Joint_Motor_t *motor, uint8_t *rx_data,uint32_t data_len);
@@ -193,6 +274,20 @@ extern void dm6006_fbdata_init(Joint_Motor_t *motor);
 extern void dm8006_fbdata_init(Joint_Motor_t *motor);
 extern void dm10010l_fbdata_init(Joint_Motor_t *motor);
 extern void dm6248p_fbdata_init(Joint_Motor_t *motor);
+
+extern const RobotJointHardwareConfig *RobotJointHardware_GetConfig(RobotJointId joint_id);
+extern bool RobotJointHardware_SetConfig(const RobotJointHardwareConfig *config);
+
+extern void RobotJointManager_Reset(void);
+extern bool RobotJointManager_Register(const RobotJointConfig *config);
+extern bool RobotJointManager_RegisterJoint(RobotJointId joint_id, Joint_Motor_t *joint, uint16_t override_mode);
+extern Joint_Motor_t *RobotJointManager_GetMotor(RobotJointId joint_id);
+extern bool RobotJointManager_SendMIT(RobotJointId joint_id, float pos, float vel, float kp, float kd, float torq);
+extern bool RobotJointManager_SendMITUsingCache(RobotJointId joint_id);
+extern bool RobotJointManager_SaveZero(RobotJointId joint_id);
+extern void RobotJointManager_EnableLimb(RobotLimb limb, uint8_t repeat, uint16_t delay_ms);
+extern void RobotJointManager_EnableAll(uint8_t repeat, uint16_t delay_ms);
+extern void RobotJointManager_HandleFeedback(hcan_t *bus, uint16_t feedback_id, uint8_t *data, uint32_t len);
 #endif /* __DM4310_DRV_H__ */
 
 


### PR DESCRIPTION
## Summary
- centralize robot joint hardware descriptions and dispatch helpers so every limb shares the same MIT command/feedback path
- refactor CAN callbacks and leg/body tasks to register joints, enable limbs, and stream cached MIT packets through the joint manager
- extend body control logic to cover waist, neck, and arms with configurable trajectories per joint

## Testing
- not run (hardware-only features)


------
https://chatgpt.com/codex/tasks/task_b_68d4f95a734c832385400b6d755c5ea0