### PR TITLE
Include control board profile source in build

### DIFF
--- a/MDK-ARM/CtrlBoard-H7_IMU.uvprojx
+++ b/MDK-ARM/CtrlBoard-H7_IMU.uvprojx
@@ -2104,6 +2104,11 @@
               <FilePath>..\User\APP\connect_task.c</FilePath>
             </File>
             <File>
+              <FileName>control_board_profile.c</FileName>
+              <FileType>1</FileType>
+              <FilePath>..\User\APP\control_board_profile.c</FilePath>
+            </File>
+            <File>
               <FileName>vbus_check.c</FileName>
               <FileType>1</FileType>
               <FilePath>..\User\APP\vbus_check.c</FilePath>


### PR DESCRIPTION
## Summary
- add the missing control_board_profile.c file to the APP group of the uVision project so it is compiled

## Testing
- not run (toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d51a8a6bd08323970087b3a1eb98be